### PR TITLE
fix(triton): fix the missing dependency in the LinalgExt dialect cmake

### DIFF
--- a/lib/Dialect/LinalgExt/IR/CMakeLists.txt
+++ b/lib/Dialect/LinalgExt/IR/CMakeLists.txt
@@ -13,6 +13,7 @@ add_triton_library(LinalgExtDialect
   LinalgExtDialect.cpp
 
   DEPENDS
+  LinalgExtTableGen
   TritonLinalgInterfacesTableGen
 
   LINK_LIBS PUBLIC


### PR DESCRIPTION
修复Dialect/LinalgExt/IR/CMakeLists.txt中LinalgExtDialect的depend缺失了LinalgExtTableGen的问题