### PR TITLE
fix(triton_to_linalg pass): add memref::LoadOp, memref::StoreOp and triton::ExternElementwiseOp as legal operation

### DIFF
--- a/lib/Conversion/TritonToLinalg/TritonToLinalg.cpp
+++ b/lib/Conversion/TritonToLinalg/TritonToLinalg.cpp
@@ -1256,6 +1256,7 @@ void TritonToLinalgPass::runOnOperation() {
       [](Operation *op) { return !op->getUsers().empty(); });
   target
       .addLegalOp<LLVM::IntToPtrOp, triton::aux::StoreResourceOp, aux::ViewOp,
+                  memref::LoadOp, memref::StoreOp,
                   bufferization::ToTensorOp, bufferization::ToMemrefOp,
                   bufferization::MaterializeInDestinationOp, aux::PrintOp,
                   aux::ScalarPrintOp>();
@@ -1274,7 +1275,8 @@ void TritonToLinalgPass::runOnOperation() {
     return !resType.isa<ShapedType>() && converter.isLegal(op);
     ;
   });
-  target.addLegalOp<triton::GetProgramIdOp, triton::GetNumProgramsOp>();
+  target.addLegalOp<triton::GetProgramIdOp, triton::GetNumProgramsOp,
+                    triton::ExternElementwiseOp>();
 
   auto solver = std::make_unique<mlir::DataFlowSolver>();
   solver->load<mlir::dataflow::DeadCodeAnalysis>();


### PR DESCRIPTION
1. file `lib/Conversion/TritonToLinalg/LoadStoreConversion.cpp`, `TritonScalarLoadOpConversion` class use `memref::LoadOp` and `TritonScalarStoreOpConversion` class use `memref::StoreOp`. Case: 05-layer-norm.py
2. `triton::ExternElementwiseOp` can mark legal op directly for triton_to_linalg pass. Case: 07-extern-functions.py