### PR TITLE
feat(triton-linalg): update triton-linlag

### DIFF
--- a/include/triton-linalg/Conversion/TritonToLinalg/TritonPointerConversion.h
+++ b/include/triton-linalg/Conversion/TritonToLinalg/TritonPointerConversion.h
@@ -153,7 +153,7 @@ public:
   int64_t getBroadcastSize() const { return broadcastSize; }
   int64_t getDimSize() const { return dimSize; }
   bool isBroadcastDim() const {
-    return getContigSize() == 1 && getDimSize() != 1;
+    return getContigSize() == 1 && getKind() == Kind::BROADCAST;
   }
 
 private:
@@ -266,8 +266,10 @@ protected:
   TritonPtrLoadStoreOpConversionBase(mlir::DataFlowSolver &solver)
       : solver{solver} {}
 
-  SmallVector<DimInfo> getDimInfos(const triton::AxisInfoExt *axisInfo,
-                                   ArrayRef<int64_t> tensorShape) const;
+  SmallVector<DimInfo>
+  getDimInfos(const triton::AxisInfoExt *axisInfo,
+              ArrayRef<int64_t> tensorShape,
+              const triton::MaskTracker &maskTracker) const;
   const triton::AxisInfoExt *getAxisInfo(Value ptr) const;
   SmallVector<int64_t> getPermutations(const triton::AxisInfoExt *axisInfo,
                                        ArrayRef<int64_t> tensorShape) const;
@@ -374,8 +376,9 @@ protected:
                      const TensorPointerMetaInfoTracker &tracker,
                      ConversionPatternRewriter &rewriter) const;
 
-  SmallVector<DimInfo> getDimInfos(ArrayRef<OpFoldResult> strides,
-                                   ArrayRef<int64_t> tensorShape) const;
+  SmallVector<DimInfo>
+  getDimInfos(ArrayRef<OpFoldResult> strides, ArrayRef<int64_t> tensorShape,
+              std::optional<ArrayRef<int>> boundaryCheck = std::nullopt) const;
 };
 
 } // namespace triton

--- a/include/triton-linalg/Dialect/Auxiliary/IR/AuxiliaryOps.td
+++ b/include/triton-linalg/Dialect/Auxiliary/IR/AuxiliaryOps.td
@@ -246,7 +246,7 @@ def PrintOp : Aux_Op<"print", [DeclareOpInterfaceMethods<MemoryEffectsOpInterfac
     ```
     %0 = aux.print(%data : tensor<128xi8>) -> (tensor<128xi8>)
     %1 = aux.print(%data : tensor<128xi8>) {format = "%d"} -> (tensor<128xi8>)
-    
+
     aux.print(%src: memref<128x16xf16, 101>) {format = "src: %hf\n"}
     aux.print(%src: memref<128x16xf32>)
 
@@ -268,7 +268,7 @@ def PrintOp : Aux_Op<"print", [DeclareOpInterfaceMethods<MemoryEffectsOpInterfac
           return isa<::mlir::MemRefType>(opOperand.getType());
         });
     }
-    
+
     ShapedType getInitType() {
       return cast<ShapedType>(getOperands()[0].getType());;
     }
@@ -293,7 +293,7 @@ def ScalarPrintOp : Aux_Op<"scalar.print", [DeclareOpInterfaceMethods<MemoryEffe
     Example:
     ```
     aux.scalar.print {format = "print test"}
-    
+
     aux.scalar.print(%data : i32)
     aux.scalar.print(%data : i32) {format = "data: %d\n"}
     aux.scalar.print(%data : i32) {format = "data: "}
@@ -304,6 +304,38 @@ def ScalarPrintOp : Aux_Op<"scalar.print", [DeclareOpInterfaceMethods<MemoryEffe
   let assemblyFormat = [{
     (`(` $values^ `:` type($values) `)` )?
     attr-dict
+  }];
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// BitcastExtOp
+//===----------------------------------------------------------------------===//
+
+def TensorOrMemref :
+    AnyTypeOf<[AnyMemRef, AnyRankedTensor], "", "::mlir::ShapedType">;
+
+// BitcastExt operation can support conversion between data types with different bit widths without
+// performing an actual data type conversion. It simply reinterprets the data as another type.
+def BitcastExtOp : Aux_Op<"bitcast_ext", [
+        DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+        DestinationStyleOpInterface]> {
+  let summary = "bitcast between values of not equal bit width";
+  let description = [{
+    Bitcast an integer or floating point value to an integer or floating point
+    value of not equal bit width.
+  }];
+
+  let arguments = (ins TensorOrMemref:$in, TensorOrMemref:$out);
+  let results = (outs Variadic<AnyTensor>:$result);
+  let assemblyFormat = [{
+    $in `,` $out `:`
+    type($in) `to` type($out)
+    attr-dict
+    (`->` type($result)^)?
+  }];
+  let extraClassDeclaration = [{
+    MutableOperandRange getDpsInitsMutable() { return getOutMutable(); }
   }];
   let hasVerifier = 1;
 }

--- a/include/triton-linalg/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/include/triton-linalg/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -847,14 +847,16 @@ def ScanOp : LinalgExtBase_Op<"scan", [
     // Dimension arg
     DenseI64ArrayAttr:$dimensions,
     // Reverse arg
-    BoolAttr:$reverse
+    BoolAttr:$reverse,
+    // Inclusive arg
+    BoolAttr:$inclusive
   );
   let results = (outs Variadic<TensorOrMemref>:$results);
   let regions = (region SizedRegion<1>:$combiner);
 
   let builders = [
     OpBuilder<(ins "ValueRange":$inputs, "ValueRange":$inits,
-      "ArrayRef<int64_t>":$dimensions, "bool":$reverse,
+      "ArrayRef<int64_t>":$dimensions, "bool":$reverse, "bool":$inclusive,
       "function_ref<void(OpBuilder &, Location, ValueRange)>",
       CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes)>
   ];
@@ -865,6 +867,7 @@ def ScanOp : LinalgExtBase_Op<"scan", [
     `outs` `(` $inits `:` type($inits) `)`
     `dimensions` `=` $dimensions
     `reverse` `=` $reverse
+    `inclusive` `=` $inclusive
     $combiner (`->` type($results)^)?
   }];
 
@@ -932,6 +935,86 @@ def ScanOp : LinalgExtBase_Op<"scan", [
   }];
 
   let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// Op definition for TriOp
+//===----------------------------------------------------------------------===//
+
+def TriOp : LinalgExtBase_Op<"tri", []> {
+  let summary = "Triangle operation.";
+  let description = [{
+    Return an tensor with elements above the k-th diagonal is filled by
+    top value, and below the k-th diagonal is filled by bottom value.
+
+    It only support rank = 2.
+
+    The purpose of this operator is to generate and apply a causal mask,
+    ensuring that each element in the sequence can only access unmasked elements.
+
+    The operation supports the following arguments:
+
+    * init: the dst tensor or memref.
+    * top: the value of the top half of the triangle.
+    * bottom: the value of the bottom half of the triangle.
+    * k: diagonal above which to top elements.
+         k = 0 (the default) is the main diagonal,
+         k < 0 is below it and k > 0 is above.
+
+    Example:
+    ```
+      %tri = linalg_ext.tri
+             ins(%top, %bottom, %k: f32, f32, index)
+             outs(%inits: tensor<4x8xf32>)
+             top(%top: f32)
+             bottom(%bottom: f32)
+             k = 3 -> tensor<16x32xf32>
+    ```
+
+    We assume top = 3, bottom = 1, It will generate the following tensor.
+
+    [[1, 1, 1, 3, 3, 3, 3, 3],
+     [1, 1, 1, 1, 3, 3, 3, 3],
+     [1, 1, 1, 1, 1, 3, 3, 3],
+     [1, 1, 1, 1, 1, 1, 3, 3]]
+
+  }];
+
+  let arguments = (ins
+    TensorOrMemref:$init,
+    AnyType:$top,
+    AnyType:$bottom,
+    Index:$k
+  );
+  let results = (outs Variadic<AnyTensor>:$result);
+
+  let builders = [
+    OpBuilder<(ins "Value":$init,
+      "Value":$top,
+      "Value":$bottom,
+      "Value":$k,
+      CArg<"ArrayRef<NamedAttribute>", "{}">:$attributes)>
+  ];
+
+  let assemblyFormat = [{attr-dict
+      `outs` `(` $init `:` type($init) `)`
+      `top` `(` $top`:` type($top) `)`
+      `bottom` `(` $bottom`:` type($bottom) `)`
+      `k` `=` $k (`->` type($result)^)?
+    }];
+  let hasFolder = 1;
+
+  let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
+    ShapedType getInitType() {
+      return mlir::cast<ShapedType>(getInit().getType());
+    }
+    LogicalResult reifyResultShapes(OpBuilder &b,
+                                    ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+      return mlir::cast<LinalgExtOp>(getOperation()).reifyResultShapes(b, reifiedReturnShapes);
+    }
+    MutableOperandRange getDpsInitsMutable() { return getInitMutable(); }
+  }];
   let hasVerifier = 1;
 }
 
@@ -1094,6 +1177,47 @@ def HistogramOp : LinalgExtBase_Op<"histogram", []> {
     LogicalResult reifyResultShapes(OpBuilder &b,
                                     ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
       return mlir::cast<LinalgExtOp>(getOperation()).reifyResultShapes(b, reifiedReturnShapes);
+    }
+    MutableOperandRange getDpsInitsMutable() { return getInitMutable(); }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// Flip op.
+//===----------------------------------------------------------------------===//
+def FlipOp : LinalgExtBase_Op<"flip", []> {
+  let summary = "Reverse the order of an n-D tensor along given axis in dim.";
+  let description = [{
+    `linalg_ext.flip` reverses the elements of a tensor (`input`) along one or more specified dimensions (`dims`).
+
+    - `input`: The input tensor to be flipped.
+    - `dims`: One or more dimensions (axes) along which the tensor will be flipped. The dimensions are indexed starting from 0.
+      If more than one axis is provided, the operation will reverse the order along each of the specified axes.
+
+    Example:
+    - For a 2D tensor `[[1, 2, 3], [4, 5, 6]]` and `dims = [0]`, the result will be `[[4, 5, 6], [1, 2, 3]]` (flipping along the first dimension).
+    - If `dims = [1]`, the result will be `[[3, 2, 1], [6, 5, 4]]` (flipping along the second dimension).
+    - If `dims = [0, 1]`, the result will be `[[6, 5, 4], [3, 2, 1]]` (flipping along both dimensions).
+  }];
+
+  let arguments = (ins
+    TensorOrMemref:$input,
+    TensorOrMemref:$init,
+    ConfinedAttr<DenseI64ArrayAttr,
+                 [DenseArrayStrictlySorted<DenseI64ArrayAttr>]>:$dims
+  );
+  let results = (outs Variadic<AnyTensor>:$result);
+
+  let assemblyFormat = [{
+    attr-dict `dims` `=` $dims
+    `ins` `(` $input `:` type($input) `)`
+    `outs` `(` $init `:` type($init) `)`
+    (`->` type($result)^)?
+  }];
+  let extraClassDeclaration =  [{
+    LogicalResult reifyResultShapes(OpBuilder &b,
+                                    ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+      return cast<LinalgExtOp>(getOperation()).reifyResultShapes(b, reifiedReturnShapes);
     }
     MutableOperandRange getDpsInitsMutable() { return getInitMutable(); }
   }];

--- a/include/triton-linalg/Dialect/LinalgExt/IR/LinalgExtStructedOps.td
+++ b/include/triton-linalg/Dialect/LinalgExt/IR/LinalgExtStructedOps.td
@@ -279,17 +279,17 @@ def Im2ColOp : LinalgStructuredBase_Op<"im2col", [AttrSizedOperandSegments]> {
 }
 
 //===----------------------------------------------------------------------===//
-// ArgMaxMinBase op.
+// NaiveReduceBase op.
 //===----------------------------------------------------------------------===//
 
-class ArgMaxMinBaseOp<string mnemonic, list<Trait> props>
+class NaiveReduceBaseOp<string mnemonic, list<Trait> props>
   : LinalgStructuredBase_Op<mnemonic, !listconcat([
     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
     SameVariadicOperandSize], props)> {
-  let summary = "Argmax/Argmin base operator";
+  let summary = "Naive reduce base operator";
   let description = [{
     Executes `combiner` on the `dimensions` of `inputs` and returns the
-    argmax/min result. The `dimensions` attribute needs to list the reduction
+    results. The `dimensions` attribute needs to list the reduction
     dimensions in increasing order.
   }];
 
@@ -355,11 +355,36 @@ class ArgMaxMinBaseOp<string mnemonic, list<Trait> props>
     MutableOperandRange getDpsInitsMutable() { return getInitsMutable(); }
   }];
 
+  let extraClassDefinition = [{
+    void $cppClass::getEffects(
+        SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+            &effects) {
+      getGenericEffectsImpl(effects, cast<LinalgOp>(getOperation()));
+    }
+    void $cppClass::getAsmResultNames(
+        function_ref<void(Value, StringRef)> setNameFn) {
+      if (!getResults().empty())
+        setNameFn(getResults().front(), getOperation()->getName().stripDialect());
+    }
+    ParseResult $cppClass::parse(OpAsmParser &parser, OperationState &result) {
+      return parseNaiveReduceOp(parser, result);
+    }
+
+    void $cppClass::print(OpAsmPrinter &p) { printNaiveReduceOp(p, *this); }
+
+    LogicalResult $cppClass::verify() { return verifyNaiveReduceOp(*this); }
+
+    LogicalResult $cppClass::fold(FoldAdaptor,
+                                      SmallVectorImpl<OpFoldResult> &) {
+      return memref::foldMemRefCast(*this);
+    }
+  }];
+
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
 }
 
-def ArgMaxOp : ArgMaxMinBaseOp<"argmax", []> {
+def ArgMaxOp : NaiveReduceBaseOp<"argmax", []> {
   let description = [{
     Example:
     ```
@@ -381,7 +406,7 @@ def ArgMaxOp : ArgMaxMinBaseOp<"argmax", []> {
   }];
 }
 
-def ArgMinOp : ArgMaxMinBaseOp<"argmin", []> {
+def ArgMinOp : NaiveReduceBaseOp<"argmin", []> {
   let description = [{
     Example:
     ```
@@ -398,6 +423,86 @@ def ArgMinOp : ArgMaxMinBaseOp<"argmin", []> {
             %5 = arith.select %4, %arg2, %arg4 : f32
             %6 = arith.select %4, %arg3, %arg5 : i32
             linalg.yield %5, %6 : f32, i32
+          }
+    ```
+  }];
+}
+
+def ReduceSumOp : NaiveReduceBaseOp<"reduce_sum", []> {
+  let description = [{
+    Example:
+    ```
+      %reduce_sum = linalg_ext.reduce_sum
+          ins(%input: tensor<16x32x64xf32>)
+          outs(%out: tensor<16x64xf32>)
+          dimensions = [1]
+          (%arg0: f32, %arg1: f32) {
+            %0 = arith.addf %arg0, %arg1 : f32
+            linalg.yield %0 : f32
+          }
+    ```
+  }];
+}
+
+def ReduceMaxOp : NaiveReduceBaseOp<"reduce_max", []> {
+  let description = [{
+    Example:
+    ```
+      %reduce_max = linalg_ext.reduce_max
+          ins(%input: tensor<16x32x64xf32>)
+          outs(%out: tensor<16x64xf32>)
+          dimensions = [1]
+          (%arg0: f32, %arg1: f32) {
+            %0 = arith.maxnumf %arg0, %arg1 : f32
+            linalg.yield %0 : f32
+          }
+    ```
+  }];
+}
+
+def ReduceMinOp : NaiveReduceBaseOp<"reduce_min", []> {
+  let description = [{
+    Example:
+    ```
+      %reduce_min = linalg_ext.reduce_min
+          ins(%input: tensor<16x32x64xf32>)
+          outs(%out: tensor<16x64xf32>)
+          dimensions = [1]
+          (%arg0: f32, %arg1: f32) {
+            %0 = arith.minnumf %arg0, %arg1 : f32
+            linalg.yield %0 : f32
+          }
+    ```
+  }];
+}
+
+def ReduceMaxNanOp : NaiveReduceBaseOp<"reduce_max_nan", []> {
+  let description = [{
+    Example:
+    ```
+      %reduce_max_nan = linalg_ext.reduce_max_nan
+          ins(%input: tensor<16x32x64xf32>)
+          outs(%out: tensor<16x64xf32>)
+          dimensions = [1]
+          (%arg0: f32, %arg1: f32) {
+            %0 = arith.maximumf %arg0, %arg1 : f32
+            linalg.yield %0 : f32
+          }
+    ```
+  }];
+}
+
+def ReduceMinNanOp : NaiveReduceBaseOp<"reduce_min_nan", []> {
+  let description = [{
+    Example:
+    ```
+      %reduce_min_nan = linalg_ext.reduce_min_nan
+          ins(%input: tensor<16x32x64xf32>)
+          outs(%out: tensor<16x64xf32>)
+          dimensions = [1]
+          (%arg0: f32, %arg1: f32) {
+            %0 = arith.minimumf %arg0, %arg1 : f32
+            linalg.yield %0 : f32
           }
     ```
   }];

--- a/include/triton-linalg/Dialect/Triton/Utils/MaskTracker.h
+++ b/include/triton-linalg/Dialect/Triton/Utils/MaskTracker.h
@@ -22,6 +22,7 @@
 namespace mlir {
 namespace triton {
 class MaskTracker;
+
 raw_ostream &operator<<(raw_ostream &os, const MaskTracker &tracker);
 //===--------------------------------------------------------------------===//
 // The main code is modified from triton-to-linalg branch in triton repo.
@@ -59,7 +60,7 @@ public:
   ArrayRef<OpFoldResult> getStarts() const { return starts; }
   void dump() const { llvm::errs() << *this << "\n"; }
 
-  /// Recursively parse a Value; call the coresponding function based on the
+  /// Recursively parse a Value; call the corresponding function based on the
   /// defining operation and Value type.
   void parse(Value operand, Location loc, RewriterBase &rewriter);
   void setDimensionStatus(int64_t dim, OpFoldResult start, OpFoldResult end,
@@ -79,6 +80,28 @@ inline raw_ostream &operator<<(raw_ostream &os, const MaskTracker &tracker) {
   }
   return os << "}";
 }
+
+/// Data structure used to decode range cmp pattern to get start, end and axis.
+/// start and end field represent the start and end index of a range (produced
+/// by make_range, addi, etc.).
+///
+/// Example of creating 2D range:
+///  range = rows[:, None]
+class RangeTracker {
+public:
+  /// Recursively parse a Value; call the corresponding function based on the
+  /// defining operation and Value type.
+  LogicalResult parse(Value operand, Location loc, RewriterBase &rewriter);
+
+  int64_t getAxis() const { return axis; }
+  OpFoldResult getStart() const { return start; }
+  OpFoldResult getEnd() const { return end; }
+
+private:
+  OpFoldResult start, end;
+  int64_t axis = -1;
+};
+
 } // namespace triton
 } // namespace mlir
 

--- a/include/triton-linalg/Dialect/Utils/ShapeUtils.h
+++ b/include/triton-linalg/Dialect/Utils/ShapeUtils.h
@@ -7,6 +7,7 @@
 #define TRITON_LINALG_DIALECT_UTILS_SHAPEUTILS_H
 #include <stdint.h>
 
+#include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Location.h"
 #include "mlir/IR/OpDefinition.h"
@@ -195,6 +196,26 @@ Value dropUnitFirstDim(OpBuilder &b, Location loc, Value value);
 /// ```
 Value collapseLastNDimsToOneDim(OpBuilder &b, Location loc, Value value,
                                 int64_t n, bool exceptLastDim = false);
+
+/// Collect the one-size dim indices from shapeVec.
+///
+/// Example1:
+/// input shapeVec: [2, ?, 4, 3, ?],
+/// output oneSizeDimIndices: [].
+///
+/// Example2:
+/// input shapeVec: [2, ?, 1, 4, 1, 3, ?],
+/// output oneSizeDimIndices: [2, 4].
+SmallVector<int64_t> getOneSizeDimIndices(ArrayRef<int64_t> shapeVec);
+
+/// Get the reassociation to build collapseShapeOp, which is used to collapse
+/// all one-size dims in operand shape.
+/// For example, if the operand shape is <32x1x?x1x1x8x16x1x?x1>,
+/// input: operandRank = 10, oneSizeDimIndices = [1, 3, 4, 7, 9];
+/// output: resultIndices= [[0, 1], [2, 3, 4], [5], [6, 7], [8, 9]].
+SmallVector<ReassociationIndices>
+getReassociationsForFoldOneSizeDim(int64_t operandRank,
+                                   ArrayRef<int64_t> oneSizeDimIndices);
 
 } // namespace triton
 } // namespace mlir

--- a/include/triton-linalg/Utils/Utils.h
+++ b/include/triton-linalg/Utils/Utils.h
@@ -51,6 +51,12 @@ OpFoldResult subOFRs(OpFoldResult lhs, OpFoldResult rhs, Location loc,
 OpFoldResult mulOFRs(OpFoldResult lhs, OpFoldResult rhs, Location loc,
                      OpBuilder &rewriter);
 
+/// Produce result = div(lhs, rhs). If both OFRs are Integer Attributes, result
+/// is an Integer Attribute. Otherwise, insert the arith.divsi instruction if
+/// needed and use its result value.
+OpFoldResult divOFRs(OpFoldResult lhs, OpFoldResult rhs, Location loc,
+                     OpBuilder &rewriter);
+
 /// Produce result = min(lhs, rhs). If both OFRs are Integer Attributes, result
 /// is an Integer Attribute. Otherwise, insert the arith.minsi instruction if
 /// needed and use its result value.

--- a/lib/Conversion/MathToLinalg/MathToLinalg.cpp
+++ b/lib/Conversion/MathToLinalg/MathToLinalg.cpp
@@ -37,16 +37,19 @@ class MLIRContext;
 void mlir::triton::populateMathToLinalgPatterns(RewritePatternSet &patterns) {
   MLIRContext *context = patterns.getContext();
   // Math ops to linalg ops.
-  patterns.add<GenericOpPattern<math::LogOp>, GenericOpPattern<math::ExpOp>,
-               GenericOpPattern<math::CosOp>, GenericOpPattern<math::SinOp>,
-               GenericOpPattern<math::SqrtOp>, GenericOpPattern<math::AbsIOp>,
-               GenericOpPattern<math::AbsFOp>, GenericOpPattern<math::TruncOp>,
-               GenericOpPattern<math::RoundOp>, GenericOpPattern<math::FloorOp>,
-               GenericOpPattern<math::FmaOp>, GenericOpPattern<math::CeilOp>,
-               GenericOpPattern<math::Log2Op>, GenericOpPattern<math::Exp2Op>,
-               GenericOpPattern<math::RsqrtOp>, GenericOpPattern<math::ErfOp>,
-               GenericOpPattern<math::TanhOp>,
-               GenericOpPattern<math_ext::MulhiUIOp>>(context);
+  patterns
+      .add<GenericOpPattern<math::LogOp>, GenericOpPattern<math::ExpOp>,
+           GenericOpPattern<math::CosOp>, GenericOpPattern<math::SinOp>,
+           GenericOpPattern<math::SqrtOp>, GenericOpPattern<math::AbsIOp>,
+           GenericOpPattern<math::AbsFOp>, GenericOpPattern<math::TruncOp>,
+           GenericOpPattern<math::RoundOp>, GenericOpPattern<math::FloorOp>,
+           GenericOpPattern<math::FmaOp>, GenericOpPattern<math::CeilOp>,
+           GenericOpPattern<math::Log2Op>, GenericOpPattern<math::Exp2Op>,
+           GenericOpPattern<math::RsqrtOp>, GenericOpPattern<math::ErfOp>,
+           GenericOpPattern<math::TanhOp>, GenericOpPattern<math::ExpM1Op>,
+           GenericOpPattern<math::Log1pOp>, GenericOpPattern<math::PowFOp>,
+           GenericOpPattern<math::FPowIOp>, GenericOpPattern<math::CopySignOp>,
+           GenericOpPattern<math_ext::MulhiUIOp>>(context);
 }
 
 namespace {

--- a/lib/Dialect/Auxiliary/Transforms/AuxOpTilingInterface.cpp
+++ b/lib/Dialect/Auxiliary/Transforms/AuxOpTilingInterface.cpp
@@ -17,8 +17,10 @@
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/DialectRegistry.h"
 #include "mlir/IR/Location.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/Operation.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/Types.h" // IWYU pragma: keep
 #include "mlir/IR/Value.h"
 #include "mlir/IR/ValueRange.h"
@@ -29,6 +31,7 @@
 #include "triton-linalg/Dialect/Auxiliary/IR/AuxiliaryDialect.h"
 #include "triton-linalg/Dialect/Auxiliary/Transforms/AuxOpTilingInterface.h"
 #include "triton-linalg/Dialect/Utils/ShapeUtils.h"
+#include "triton-linalg/Utils/Utils.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Sequence.h"
@@ -46,6 +49,11 @@ class MLIRContext;
 } // namespace mlir
 
 namespace {
+
+static bool isDivisible(OpFoldResult lhs, unsigned rhs) {
+  auto lhsIntAttr = getConstantIntValue(lhs);
+  return !lhsIntAttr && rhs != 0 && lhsIntAttr.value() % rhs == 0;
+}
 
 struct PrintOpTilingInterface
     : public TilingInterface::ExternalModel<PrintOpTilingInterface,
@@ -124,6 +132,109 @@ struct PrintOpTilingInterface
         "Unreachable code reached in generateScalarImplementation");
   }
 };
+
+struct BitcastExtOpTilingInterface
+    : public TilingInterface::ExternalModel<BitcastExtOpTilingInterface,
+                                            triton::aux::BitcastExtOp> {
+  SmallVector<utils::IteratorType> getLoopIteratorTypes(Operation *op) const {
+    triton::aux::BitcastExtOp bitcastExtOp =
+        cast<triton::aux::BitcastExtOp>(op);
+    SmallVector<utils::IteratorType> loops(
+        cast<ShapedType>(bitcastExtOp.getIn().getType()).getRank(),
+        utils::IteratorType::parallel);
+    return loops;
+  }
+
+  // Tile init then update.
+  SmallVector<Range> getIterationDomain(Operation *op, OpBuilder &b) const {
+    triton::aux::BitcastExtOp bitcastExtOp =
+        cast<triton::aux::BitcastExtOp>(op);
+    Location loc = op->getLoc();
+    Value zero = b.create<arith::ConstantIndexOp>(loc, 0);
+    Value one = b.create<arith::ConstantIndexOp>(loc, 1);
+    SmallVector<Range> ranges;
+    for (auto dim : llvm::seq<int64_t>(
+             0, cast<ShapedType>(bitcastExtOp.getIn().getType()).getRank())) {
+      OpFoldResult ub = getDim(b, loc, bitcastExtOp.getIn(), dim);
+      ranges.emplace_back(Range{zero, ub, one});
+    }
+    return ranges;
+  }
+
+  FailureOr<TilingResult>
+  getTiledImplementation(Operation *op, OpBuilder &b,
+                         ArrayRef<OpFoldResult> offsets,
+                         ArrayRef<OpFoldResult> sizes) const {
+    triton::aux::BitcastExtOp bitcastExtOp =
+        cast<triton::aux::BitcastExtOp>(op);
+    Location loc = bitcastExtOp.getLoc();
+    auto inType = cast<ShapedType>(bitcastExtOp.getIn().getType());
+    auto outType = cast<ShapedType>(bitcastExtOp.getOut().getType());
+    int64_t rank = inType.getRank();
+
+    SmallVector<OpFoldResult> inputOffsets(offsets.begin(), offsets.end());
+    SmallVector<OpFoldResult> inputSizes(sizes.begin(), sizes.end());
+    auto oneAttr = b.getI64IntegerAttr(1);
+    SmallVector<OpFoldResult> strides(rank, oneAttr);
+
+    auto inputSlice = b.create<tensor::ExtractSliceOp>(
+        loc, bitcastExtOp.getIn(), inputOffsets, inputSizes, strides);
+    unsigned inBitwidth = inType.getElementType().getIntOrFloatBitWidth();
+    unsigned outBitwidth = outType.getElementType().getIntOrFloatBitWidth();
+    SmallVector<OpFoldResult> outputOffsets(offsets.begin(), offsets.end());
+    SmallVector<OpFoldResult> outputSizes(sizes.begin(), sizes.end());
+    if (inBitwidth != outBitwidth) {
+      auto inBitwidthAttr = IntegerAttr::get(inType, inBitwidth);
+      auto outBitwidthAttr = IntegerAttr::get(outType, outBitwidth);
+      for (size_t i = 0; i < offsets.size(); ++i) {
+        if (inBitwidth < outBitwidth) {
+          unsigned bitwidthMultiple = outBitwidth / inBitwidth;
+          if (!isDivisible(inputOffsets[i], bitwidthMultiple)) {
+            return op->emitOpError(
+                "When transitioning from low bit width to high "
+                "bit width, offset needs to be divided by a multiple of the "
+                "bit width");
+          }
+        }
+        OpFoldResult tempOffset =
+            mulOFRs(inputOffsets[i], inBitwidthAttr, loc, b);
+        OpFoldResult tempSize = mulOFRs(inputSizes[i], inBitwidthAttr, loc, b);
+        outputOffsets.push_back(divOFRs(tempOffset, outBitwidthAttr, loc, b));
+        outputSizes.push_back(divOFRs(tempSize, outBitwidthAttr, loc, b));
+      }
+    }
+    auto outputSlice = b.create<tensor::ExtractSliceOp>(
+        loc, bitcastExtOp.getOut(), outputOffsets, outputSizes, strides);
+
+    Operation *tiledOp = b.create<triton::aux::BitcastExtOp>(
+        loc, outputSlice.getType(), inputSlice, outputSlice);
+
+    return TilingResult{{tiledOp}, SmallVector<Value>(tiledOp->getResults())};
+  }
+
+  LogicalResult
+  getResultTilePosition(Operation *op, OpBuilder &b, unsigned resultNumber,
+                        ArrayRef<OpFoldResult> offsets,
+                        ArrayRef<OpFoldResult> sizes,
+                        SmallVector<OpFoldResult> &resultOffsets,
+                        SmallVector<OpFoldResult> &resultSizes) const {
+    resultOffsets = canonicalizeOpFoldResult(offsets);
+    resultSizes = canonicalizeOpFoldResult(sizes);
+    return success();
+  }
+
+  FailureOr<TilingResult>
+  generateResultTileValue(Operation *op, OpBuilder &b, unsigned resultNumber,
+                          ArrayRef<OpFoldResult> offsets,
+                          ArrayRef<OpFoldResult> sizes) const {
+    auto tilingInterfaceOp = cast<TilingInterface>(op);
+    FailureOr<TilingResult> tilingResult =
+        tilingInterfaceOp.getTiledImplementation(b, offsets, sizes);
+    if (tilingResult->tiledOps.size() != 1)
+      return op->emitOpError("failed to generate tiled implementation");
+    return tilingResult;
+  }
+};
 } // namespace
 
 void mlir::triton::aux::registerTilingInterfaceExternalModels(
@@ -131,5 +242,7 @@ void mlir::triton::aux::registerTilingInterfaceExternalModels(
   registry.addExtension(
       +[](MLIRContext *ctx, triton::aux::AuxiliaryDialect *dialect) {
         triton::aux::PrintOp::attachInterface<PrintOpTilingInterface>(*ctx);
+        triton::aux::BitcastExtOp::attachInterface<BitcastExtOpTilingInterface>(
+            *ctx);
       });
 }

--- a/test/Conversion/math-to-linalg.mlir
+++ b/test/Conversion/math-to-linalg.mlir
@@ -364,3 +364,55 @@ func.func @math_tanh_tensor_partial_static(%arg0: tensor<128x?xf32>) {
   %0 = math.tanh %arg0 : tensor<128x?xf32>
   return
 }
+
+// -----
+func.func @math_powf_scalar(%arg0: f32, %arg1: f32) {
+  // CHECK: math.powf %arg0, %arg1 : f32
+  // CHECK-NOT: linalg.map
+  %0 = math.powf %arg0, %arg1 : f32
+  return
+}
+
+// -----
+func.func @math_fpowi_scalar(%arg0: f32, %arg1: i32) {
+  // CHECK: math.fpowi %arg0, %arg1 : f32, i32
+  // CHECK-NOT: linalg.map
+  %0 = math.fpowi %arg0, %arg1 : f32, i32
+  return
+}
+
+// -----
+func.func @math_powf_tensor_staic(%arg0: tensor<128xf32>, %arg1: tensor<128xf32>) {
+  // CHECK: %[[INIT:.*]] = tensor.empty() : tensor<128xf32>
+  // CHECK: %[[MAPPED:.*]] = linalg.map { math.powf } ins(%arg0, %arg1 : tensor<128xf32>, tensor<128xf32>) outs(%[[INIT]] : tensor<128xf32>)
+  %0 = math.powf %arg0, %arg1 : tensor<128xf32>
+  return
+}
+
+// -----
+func.func @math_fpowi_tensor_staic(%arg0: tensor<128xf32>, %arg1: tensor<128xi32>) {
+  // CHECK: %[[INIT:.*]] = tensor.empty() : tensor<128xf32>
+  // CHECK: %[[MAPPED:.*]] = linalg.map { math.fpowi } ins(%arg0, %arg1 : tensor<128xf32>, tensor<128xi32>) outs(%[[INIT]] : tensor<128xf32>)
+  %0 = math.fpowi %arg0, %arg1 : tensor<128xf32>, tensor<128xi32>
+  return
+}
+
+// -----
+func.func @math_powf_tensor_partial_static(%arg0: tensor<128x?xf32>, %arg1: tensor<128x?xf32>) {
+  // CHECK: %[[CST:.*]] = arith.constant 1 : index
+  // CHECK: %[[DYNAMIC_DIM:.*]] = tensor.dim %arg0, %[[CST]] : tensor<128x?xf32>
+  // CHECK: %[[INIT:.*]] = tensor.empty(%[[DYNAMIC_DIM]]) : tensor<128x?xf32>
+  // CHECK: %[[MAPPED:.*]] = linalg.map { math.powf } ins(%arg0, %arg1 : tensor<128x?xf32>, tensor<128x?xf32>) outs(%[[INIT]] : tensor<128x?xf32>)
+  %0 = math.powf %arg0, %arg1 : tensor<128x?xf32>
+  return
+}
+
+// -----
+func.func @math_fpowi_tensor_partial_static(%arg0: tensor<128x?xf32>, %arg1: tensor<128x?xi32>) {
+  // CHECK: %[[CST:.*]] = arith.constant 1 : index
+  // CHECK: %[[DYNAMIC_DIM:.*]] = tensor.dim %arg0, %[[CST]] : tensor<128x?xf32>
+  // CHECK: %[[INIT:.*]] = tensor.empty(%[[DYNAMIC_DIM]]) : tensor<128x?xf32>
+  // CHECK: %[[MAPPED:.*]] = linalg.map { math.fpowi } ins(%arg0, %arg1 : tensor<128x?xf32>, tensor<128x?xi32>) outs(%[[INIT]] : tensor<128x?xf32>)
+  %0 = math.fpowi %arg0, %arg1 : tensor<128x?xf32>, tensor<128x?xi32>
+  return
+}

--- a/test/Dialect/Triton/ptr-strength-reduction.mlir
+++ b/test/Dialect/Triton/ptr-strength-reduction.mlir
@@ -197,11 +197,11 @@ tt.func @control_flow_br_test(%arg0: !tt.ptr<f32>) -> (tensor<128xf32>, tensor<1
 
 // -----
 // CHECK-LABEL: tt.func @control_flow_br_with_blockptr_test
-// CHECK:      cf.br ^bb1(%c128_i64, %c64_i64, %c1_i64, %c1_i64, %c0_i32, %c0_i32 : i64, i64, i64, i64, i32, i32)
-// CHECK-NEXT: ^bb1(%0: i64, %1: i64, %2: i64, %3: i64, %4: i32, %5: i32):  // pred: ^bb0
-// CHECK-NEXT:   %[[ARG1:.*]] = arith.addi %arg1, %4 : i32
-// CHECK-NEXT:   %[[ARG2:.*]] = arith.addi %arg2, %5 : i32
-// CHECK-NEXT:   %[[TENSOR_PTR:.*]] = tt.make_tensor_ptr %arg0, [%0, %1], [%2, %3], [%[[ARG1]], %[[ARG2]]] {order = array<i32: 0, 1>} : <tensor<32x32xf32>>
+// CHECK: cf.br ^bb1(%arg0, %c128_i64, %c64_i64, %c1_i64, %c1_i64, %c0_i32, %c0_i32 : !tt.ptr<f32>, i64, i64, i64, i64, i32, i32)
+// CHECK-NEXT: ^bb1(%0: !tt.ptr<f32>, %1: i64, %2: i64, %3: i64, %4: i64, %5: i32, %6: i32):  // pred: ^bb0
+// CHECK-NEXT:   %[[ARG1:.*]] = arith.addi %arg1, %5 : i32
+// CHECK-NEXT:   %[[ARG2:.*]] = arith.addi %arg2, %6 : i32
+// CHECK-NEXT:   %[[TENSOR_PTR:.*]] = tt.make_tensor_ptr %0, [%1, %2], [%3, %4], [%7, %8] {order = array<i32: 0, 1>} : <tensor<32x32xf32>>
 tt.func @control_flow_br_with_blockptr_test(%arg0: !tt.ptr<f32>, %arg1: i32, %arg2: i32) -> tensor<32x32xf32> {
   %c128_i64 = arith.constant 128 : i64
   %c64_i64 = arith.constant 64 : i64
@@ -241,16 +241,16 @@ tt.func @control_flow_cond_br_test(%arg0: !tt.ptr<f32>, %arg1: i1) -> tensor<128
 
 // -----
 // CHECK-LABEL: tt.func @for_test
-// CHECK:      %[[RESULT:.*]] = scf.for %arg1 = %c0 to %c128 step %c32 iter_args(%arg2 = %0) -> (tensor<32xi32>) {
+// CHECK: %[[RESULT:.*]]:[[RESULT_NUL:.*]] = scf.for %arg1 = %c0 to %c128 step %c32 iter_args(%arg2 = %arg0, %arg3 = %0) -> (!tt.ptr<f32>, tensor<32xi32>) {
 // CHECK-NEXT:   %[[TEMP0:.*]] = arith.index_cast %arg1 : index to i32
 // CHECK-NEXT:   %[[TEMP1:.*]] = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
 // CHECK-NEXT:   %[[TEMP2:.*]] = tt.splat %[[TEMP0]] : i32 -> tensor<32xi32>
 // CHECK-NEXT:   %[[TEMP3:.*]] = arith.addi %[[TEMP1]], %[[TEMP2]] : tensor<32xi32>
-// CHECK-NEXT:   %[[TEMP4:.*]] = arith.addi %[[TEMP3]], %arg2 : tensor<32xi32>
-// CHECK-NEXT:   scf.yield %[[TEMP4]] : tensor<32xi32>
+// CHECK-NEXT:   %[[TEMP4:.*]] = arith.addi %[[TEMP3]], %arg3 : tensor<32xi32>
+// CHECK-NEXT:   scf.yield %arg2, %[[TEMP4]] : !tt.ptr<f32>, tensor<32xi32>
 // CHECK-NEXT: }
-// CHECK-NEXT: %[[TEMP5:.*]] = tt.splat %arg0 : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>>
-// CHECK-NEXT: %[[RESULT1:.*]] = tt.addptr %[[TEMP5]], %[[RESULT]] : tensor<32x!tt.ptr<f32>>, tensor<32xi32>
+// CHECK-NEXT: %[[TEMP5:.*]] = tt.splat %[[RESULT]]#0 : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>>
+// CHECK-NEXT: %[[RESULT1:.*]] = tt.addptr %[[TEMP5]], %[[RESULT]]#1 : tensor<32x!tt.ptr<f32>>, tensor<32xi32>
 tt.func @for_test(%arg0: !tt.ptr<f32>) -> tensor<32xf32> {
   %c0 = arith.constant 0 : index
   %c128 = arith.constant 128 : index
@@ -303,16 +303,16 @@ tt.func @for_with_execute_region_test(%arg0 : i1) {
 
 // -----
 // CHECK-LABEL: tt.func @for_with_blockptr_test
-// CHECK:      %[[ARG0:.*]]:12 = scf.for %arg2 = %c0 to %c128 step %c32 iter_args(%arg3 = %c128_i64, %arg4 = %c64_i64, %arg5 = %c1_i64, %arg6 = %c1_i64, %arg7 = %c0_i32, %arg8 = %c0_i32, %arg9 = %c128_i64, %arg10 = %c64_i64, %arg11 = %c1_i64, %arg12 = %c1_i64, %arg13 = %c0_i32, %arg14 = %c0_i32) -> (i64, i64, i64, i64, i32, i32, i64, i64, i64, i64, i32, i32)
+// CHECK:      %[[ARG0:.*]]:14 = scf.for %arg2 = %c0 to %c128 step %c32 iter_args(%arg3 = %arg0, %arg4 = %c128_i64, %arg5 = %c64_i64, %arg6 = %c1_i64, %arg7 = %c1_i64, %arg8 = %c0_i32, %arg9 = %c0_i32, %arg10 = %arg0, %arg11 = %c128_i64, %arg12 = %c64_i64, %arg13 = %c1_i64, %arg14 = %c1_i64, %arg15 = %c0_i32, %arg16 = %c0_i32) -> (!tt.ptr<f32>, i64, i64, i64, i64, i32, i32, !tt.ptr<f32>, i64, i64, i64, i64, i32, i32) {
 // CHECK-NEXT:   %[[ARG2:.*]] = arith.index_cast %arg2 : index to i32
-// CHECK-NEXT:   %[[ARG6:.*]] = arith.addi %arg1, %arg7 : i32
-// CHECK-NEXT:   %[[ARG7:.*]] = arith.addi %[[ARG2]], %arg8 : i32
-// CHECK-NEXT:   %[[ARG8:.*]] = arith.addi %[[ARG2]], %arg13 : i32
-// CHECK-NEXT:   %[[ARG9:.*]] = arith.addi %[[ARG2]], %arg14 : i32
-// CHECK-NEXT:   scf.yield %arg3, %arg4, %arg5, %arg6, %[[ARG6]], %[[ARG7]], %arg9, %arg10, %arg11, %arg12, %[[ARG8]], %[[ARG9]] : i64, i64, i64, i64, i32, i32, i64, i64, i64, i64, i32, i32
+// CHECK-NEXT:   %[[ARG6:.*]] = arith.addi %arg1, %arg8 : i32
+// CHECK-NEXT:   %[[ARG7:.*]] = arith.addi %[[ARG2]], %arg9 : i32
+// CHECK-NEXT:   %[[ARG8:.*]] = arith.addi %[[ARG2]], %arg15 : i32
+// CHECK-NEXT:   %[[ARG9:.*]] = arith.addi %[[ARG2]], %arg16 : i32
+// CHECK-NEXT:   scf.yield %arg3, %arg4, %arg5, %arg6, %arg7, %6, %7, %arg10, %arg11, %arg12, %arg13, %arg14, %[[ARG8]], %[[ARG9]] : !tt.ptr<f32>, i64, i64, i64, i64, i32, i32, !tt.ptr<f32>, i64, i64, i64, i64, i32, i32
 // CHECK-NEXT:   }
-// CHECK-NEXT: %1 = tt.make_tensor_ptr %arg0, [%[[ARG0]]#6, %[[ARG0]]#7], [%[[ARG0]]#8, %[[ARG0]]#9], [%[[ARG0]]#10, %[[ARG0]]#11] {order = array<i32: 0, 1>} : <tensor<32x32xf32>>
-// CHECK-NEXT: %2 = tt.make_tensor_ptr %arg0, [%[[ARG0]]#0, %[[ARG0]]#1], [%[[ARG0]]#2, %[[ARG0]]#3], [%[[ARG0]]#4, %[[ARG0]]#5] {order = array<i32: 0, 1>} : <tensor<32x32xf32>>
+// CHECK-NEXT:   %1 = tt.make_tensor_ptr %[[ARG0]]#7, [%[[ARG0]]#8, %[[ARG0]]#9], [%[[ARG0]]#10, %[[ARG0]]#11], [%[[ARG0]]#12, %[[ARG0]]#13] {order = array<i32: 0, 1>} : <tensor<32x32xf32>>
+// CHECK-NEXT:   %2 = tt.make_tensor_ptr %[[ARG0]]#0, [%[[ARG0]]#1, %[[ARG0]]#2], [%[[ARG0]]#3, %[[ARG0]]#4], [%[[ARG0]]#5, %[[ARG0]]#6] {order = array<i32: 0, 1>} : <tensor<32x32xf32>>
 tt.func @for_with_blockptr_test(%arg0: !tt.ptr<f32>, %arg1: i32) -> (tensor<32x32xf32>, tensor<32x32xf32>) {
   %c0 = arith.constant 0 : index
   %c128 = arith.constant 128 : index
@@ -336,22 +336,22 @@ tt.func @for_with_blockptr_test(%arg0: !tt.ptr<f32>, %arg1: i32) -> (tensor<32x3
 
 // -----
 // CHECK-LABEL: tt.func @nest_for_test
-// CHECK:      %[[RESULT1:.*]]{{:.*}} = scf.for %arg1 = %c0 to %c128 step %c32 iter_args(%arg2 = %0, %arg3 = %0) -> (tensor<32xi32>, tensor<32xi32>) {
+// CHECK:      %[[RESULT1:.*]]:3 = scf.for %arg1 = %c0 to %c128 step %c32 iter_args(%arg2 = %0, %arg3 = %arg0, %arg4 = %0) -> (tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>) {
 // CHECK-NEXT:   %[[TEMP0:.*]] = arith.index_cast %arg1 : index to i32
 // CHECK-NEXT:   %[[TEMP1:.*]] = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
 // CHECK-NEXT:   %[[TEMP2:.*]] = tt.splat %[[TEMP0]] : i32 -> tensor<32xi32>
-// CHECK-NEXT:   %[[RESULT2:.*]]:2 = scf.for %arg4 = %c0 to %c128 step %c32 iter_args(%arg5 = %[[TEMP2]], %arg6 = %arg3) -> (tensor<32xi32>, tensor<32xi32>) {
-// CHECK-NEXT:     %[[TEMP3:.*]] = arith.index_cast %arg4 : index to i32
+// CHECK-NEXT:   %[[RESULT2:.*]]:3 = scf.for %arg5 = %c0 to %c128 step %c32 iter_args(%arg6 = %7, %arg7 = %arg3, %arg8 = %arg4) -> (tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>) {
+// CHECK-NEXT:     %[[TEMP3:.*]] = arith.index_cast %arg5 : index to i32
 // CHECK-NEXT:     %[[TEMP4:.*]] = tt.splat %[[TEMP3]] : i32 -> tensor<32xi32>
-// CHECK-NEXT:     %[[TEMP5:.*]] = arith.addi %[[TEMP4]], %arg6 : tensor<32xi32>
-// CHECK-NEXT:     scf.yield %[[TEMP4]], %[[TEMP5]] : tensor<32xi32>, tensor<32xi32>
+// CHECK-NEXT:     %[[TEMP5:.*]] = arith.addi %[[TEMP4]], %arg8 : tensor<32xi32>
+// CHECK-NEXT:     scf.yield %[[TEMP4]], %arg7, %[[TEMP5]] : tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>
 // CHECK-NEXT:   }
 // CHECK-NEXT:   %[[TEMP6:.*]] = arith.addi %[[TEMP1]], %[[RESULT2]]#0 : tensor<32xi32>
-// CHECK-NEXT:   %[[TEMP7:.*]] = arith.addi %[[TEMP6]], %[[RESULT2]]#1 : tensor<32xi32>
-// CHECK-NEXT:   scf.yield %[[TEMP6]], %[[TEMP7]] : tensor<32xi32>, tensor<32xi32>
+// CHECK-NEXT:   %[[TEMP7:.*]] = arith.addi %[[TEMP6]], %[[RESULT2]]#2 : tensor<32xi32>
+// CHECK-NEXT:   scf.yield %[[TEMP6]], %8#1, %[[TEMP7]] : tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>
 // CHECK-NEXT: }
-// CHECK-NEXT: %[[TEMP8:.*]] = tt.splat %arg0 : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>>
-// CHECK-NEXT: %[[RESULT3:.*]] = tt.addptr %[[TEMP8]], %[[RESULT1]]#1 : tensor<32x!tt.ptr<f32>>, tensor<32xi32>
+// CHECK-NEXT: %[[TEMP8:.*]] = tt.splat %[[RESULT1]]#1 : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>>
+// CHECK-NEXT: %3 = tt.addptr %[[TEMP8]], %[[RESULT1]]#2 : tensor<32x!tt.ptr<f32>>, tensor<32xi32>
 tt.func @nest_for_test(%arg0: !tt.ptr<f32>) -> tensor<32xf32> {
   %c0 = arith.constant 0 : index
   %c128 = arith.constant 128 : index
@@ -379,19 +379,19 @@ tt.func @nest_for_test(%arg0: !tt.ptr<f32>) -> tensor<32xf32> {
 
 // -----
 // CHECK-LABEL: tt.func @for_multi_ptr_test
-// CHECK:      %[[RESULT1:.*]]{{:.*}} = scf.for %arg2 = %c0 to %c128 step %c32 iter_args(%arg3 = %0, %arg4 = %0, %arg5 = %0) -> (tensor<32xi32>, tensor<32xi32>, tensor<32xi32>) {
+// CHECK:      %[[RESULT1:.*]]{{:.*}} = scf.for %arg2 = %c0 to %c128 step %c32 iter_args(%arg3 = %0, %arg4 = %arg0, %arg5 = %0, %arg6 = %arg1, %arg7 = %0) -> (tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>) {
 // CHECK-NEXT:   %[[TEMP0:.*]] = arith.index_cast %arg2 : index to i32
 // CHECK-NEXT:   %[[TEMP1:.*]] = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
 // CHECK-NEXT:   %[[TEMP2:.*]] = tt.splat %[[TEMP0]] : i32 -> tensor<32xi32>
 // CHECK-NEXT:   %[[TEMP3:.*]] = arith.addi %[[TEMP1]], %[[TEMP2]] : tensor<32xi32>
-// CHECK-NEXT:   %[[TEMP4:.*]] = arith.addi %[[TEMP3]], %arg4 : tensor<32xi32>
-// CHECK-NEXT:   %[[TEMP5:.*]] = arith.addi %[[TEMP2]], %arg5 : tensor<32xi32>
-// CHECK-NEXT:   scf.yield %[[TEMP3]], %[[TEMP4]], %[[TEMP5]] : tensor<32xi32>, tensor<32xi32>, tensor<32xi32>
+// CHECK-NEXT:   %[[TEMP4:.*]] = arith.addi %[[TEMP3]], %arg5 : tensor<32xi32>
+// CHECK-NEXT:   %[[TEMP5:.*]] = arith.addi %[[TEMP2]], %arg7 : tensor<32xi32>
+// CHECK-NEXT:   scf.yield %[[TEMP3]], %arg4, %[[TEMP4]], %arg6, %[[TEMP5]] : tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>
 // CHECK-NEXT: }
-// CHECK-NEXT: %[[TEMP6:.*]] = tt.splat %arg1 : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>>
-// CHECK-NEXT: %[[RESULT2:.*]] = tt.addptr %[[TEMP6]], %[[RESULT1]]#2 : tensor<32x!tt.ptr<f32>>, tensor<32xi32>
-// CHECK-NEXT: %[[TEMP7:.*]] = tt.splat %arg0 : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>>
-// CHECK-NEXT: %[[RESULT3:.*]] = tt.addptr %[[TEMP7]], %[[RESULT1]]#1 : tensor<32x!tt.ptr<f32>>, tensor<32xi32>
+// CHECK-NEXT: %[[TEMP6:.*]] = tt.splat %[[RESULT1]]#3 : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>>
+// CHECK-NEXT: %[[RESULT2:.*]] = tt.addptr %[[TEMP6]], %[[RESULT1]]#4 : tensor<32x!tt.ptr<f32>>, tensor<32xi32>
+// CHECK-NEXT: %[[TEMP7:.*]] = tt.splat %[[RESULT1]]#1 : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>>
+// CHECK-NEXT: %[[RESULT3:.*]] = tt.addptr %[[TEMP7]], %[[RESULT1]]#2 : tensor<32x!tt.ptr<f32>>, tensor<32xi32>
 tt.func @for_multi_ptr_test(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>) -> (tensor<32xf32>, tensor<32xf32>) {
   %c0 = arith.constant 0 : index
   %c128 = arith.constant 128 : index
@@ -417,17 +417,17 @@ tt.func @for_multi_ptr_test(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>) -> (tensor
 
 // -----
 // CHECK-LABEL: tt.func @while_test
-// CHECK:      %[[RESULT1:.*]] = scf.while (%arg2 = %0) : (tensor<32xi32>) -> tensor<32xi32> {
+// CHECK:        %[[RESULT1:.*]]:2 = scf.while (%arg2 = %arg0, %arg3 = %0) : (!tt.ptr<f32>, tensor<32xi32>) -> (!tt.ptr<f32>, tensor<32xi32>) {
 // CHECK-NEXT:   %[[TEMP0:.*]] = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-// CHECK-NEXT:   %[[TEMP1:.*]] = arith.addi %[[TEMP0]], %arg2 : tensor<32xi32>
-// CHECK-NEXT:   scf.condition(%arg1) %[[TEMP1]] : tensor<32xi32>
+// CHECK-NEXT:   %[[TEMP1:.*]] = arith.addi %[[TEMP0]], %arg3 : tensor<32xi32>
+// CHECK-NEXT:  scf.condition(%arg1) %arg2, %[[TEMP1]] : !tt.ptr<f32>, tensor<32xi32>
 // CHECK-NEXT: } do {
-// CHECK-NEXT:   ^bb0(%arg2: tensor<32xi32>):
-// CHECK-NEXT:     %[[TEMP2:.*]] = arith.addi %arg2, %cst : tensor<32xi32>
-// CHECK-NEXT:     scf.yield %[[TEMP2]] : tensor<32xi32>
+// CHECK-NEXT:   ^bb0(%arg2: !tt.ptr<f32>, %arg3: tensor<32xi32>):
+// CHECK-NEXT:     %[[TEMP2:.*]] = arith.addi %arg3, %cst
+// CHECK-NEXT:     scf.yield %arg2, %[[TEMP2]] : !tt.ptr<f32>, tensor<32xi32>
 // CHECK-NEXT: }
-// CHECK-NEXT: %[[TEMP3:.*]] = tt.splat %arg0 : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>>
-// CHECK-NEXT: %[[RESULT2:.*]] = tt.addptr %[[TEMP3]], %[[RESULT1]] : tensor<32x!tt.ptr<f32>>, tensor<32xi32>
+// CHECK-NEXT: %[[TEMP3:.*]] = tt.splat %[[RESULT1]]#0 : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>>
+// CHECK-NEXT: %[[RESULT2:.*]] = tt.addptr %[[TEMP3]], %[[RESULT1]]#1 : tensor<32x!tt.ptr<f32>>, tensor<32xi32>
 tt.func @while_test(%arg0: !tt.ptr<f32>, %arg1: i1) -> tensor<32xf32> {
   %cst = arith.constant dense<2> : tensor<32xi32>
   %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
@@ -448,17 +448,17 @@ tt.func @while_test(%arg0: !tt.ptr<f32>, %arg1: i1) -> tensor<32xf32> {
 
 // -----
 // CHECK-LABEL: tt.func @while_with_block_ptr_test
-// CHECK:      %[[ARG0:.*]]:6 = scf.while (%arg4 = %c128_i64, %arg5 = %c64_i64, %arg6 = %c1_i64, %arg7 = %c1_i64, %arg8 = %c0_i32, %arg9 = %c0_i32) : (i64, i64, i64, i64, i32, i32) -> (i64, i64, i64, i64, i32, i32)
-// CHECK-NEXT:   %[[COND_ARG4:.*]] = arith.addi %arg2, %arg8 : i32
-// CHECK-NEXT:   %[[COND_ARG5:.*]] = arith.addi %arg3, %arg9 : i32
-// CHECK-NEXT:   scf.condition(%arg1) %arg4, %arg5, %arg6, %arg7, %[[COND_ARG4]], %[[COND_ARG5]] : i64, i64, i64, i64, i32, i32
+// CHECK:        %[[ARG0:.*]]:7 = scf.while (%arg4 = %arg0, %arg5 = %c128_i64, %arg6 = %c64_i64, %arg7 = %c1_i64, %arg8 = %c1_i64, %arg9 = %c0_i32, %arg10 = %c0_i32) : (!tt.ptr<f32>, i64, i64, i64, i64, i32, i32) -> (!tt.ptr<f32>, i64, i64, i64, i64, i32, i32) {
+// CHECK-NEXT:   %[[COND_ARG4:.*]] = arith.addi %arg2, %arg9 : i32
+// CHECK-NEXT:   %[[COND_ARG5:.*]] = arith.addi %arg3, %arg10 : i32
+// CHECK-NEXT:   scf.condition(%arg1) %arg4, %arg5, %arg6, %arg7, %arg8, %[[COND_ARG4]], %[[COND_ARG5]] : !tt.ptr<f32>, i64, i64, i64, i64, i32, i32
 // CHECK-NEXT: } do {
-// CHECK-NEXT: ^bb0(%arg4: i64, %arg5: i64, %arg6: i64, %arg7: i64, %arg8: i32, %arg9: i32):
-// CHECK-NEXT:   %[[BODY_ARG4:.*]] = arith.addi %arg2, %arg8 : i32
-// CHECK-NEXT:   %[[BODY_ARG5:.*]] = arith.addi %arg3, %arg9 : i32
-// CHECK-NEXT:   scf.yield %arg4, %arg5, %arg6, %arg7, %[[BODY_ARG4]], %[[BODY_ARG5]] : i64, i64, i64, i64, i32, i32
+// CHECK-NEXT:  ^bb0(%arg4: !tt.ptr<f32>, %arg5: i64, %arg6: i64, %arg7: i64, %arg8: i64, %arg9: i32, %arg10: i32):
+// CHECK-NEXT:   %[[BODY_ARG4:.*]] = arith.addi %arg2, %arg9 : i32
+// CHECK-NEXT:   %[[BODY_ARG5:.*]] = arith.addi %arg3, %arg10 : i32
+// CHECK-NEXT:   scf.yield %arg4, %arg5, %arg6, %arg7, %arg8, %[[BODY_ARG4]], %[[BODY_ARG5]] : !tt.ptr<f32>, i64, i64, i64, i64, i32, i32
 // CHECK-NEXT: }
-// CHECK-NEXT: tt.make_tensor_ptr %arg0, [%[[ARG0]]#0, %[[ARG0]]#1], [%[[ARG0]]#2, %[[ARG0]]#3], [%[[ARG0]]#4, %[[ARG0]]#5] {order = array<i32: 0, 1>} : <tensor<32x32xf32>>
+// CHECK-NEXT: tt.make_tensor_ptr %[[ARG0]]#0, [%[[ARG0]]#1, %[[ARG0]]#2], [%[[ARG0]]#3, %[[ARG0]]#4], [%[[ARG0]]#5, %[[ARG0]]#6] {order = array<i32: 0, 1>} : <tensor<32x32xf32>>
 tt.func @while_with_block_ptr_test(%arg0: !tt.ptr<f32>, %arg1: i1, %arg2: i32, %arg3: i32) -> tensor<32x32xf32> {
   %c128_i64 = arith.constant 128 : i64
   %c64_i64 = arith.constant 64 : i64
@@ -634,8 +634,11 @@ tt.func @if_multi_return_test(%arg0: !tt.ptr<f32>, %arg1: i1) -> tensor<32xf32> 
 // -----
 // CHECK-LABEL: tt.func @for_multi_iter_args_test
 // CHECK: %[[RESULT:.*]] = arith.addi %54, %0 : tensor<32xi32>
-// CHECK-NEXT %[[RESULT1:.*]]:11 = scf.for %arg1 = %c0 to %c128 step %c32 iter_args(%arg2 = %0, %arg3 = %1, %arg4 = %3, %arg5 = %6, %arg6 = %10, %arg7 = %15, %arg8 = %21, %arg9 = %28, %arg10 = %36, %arg11 = %45, %arg12 = %55) -> (tensor<32xi32>, tensor<32xi32>, tensor<32xi32>, tensor<32xi32>, tensor<32xi32>, tensor<32xi32>, tensor<32xi32>, tensor<32xi32>, tensor<32xi32>, tensor<32xi32>, tensor<32xi32>) {
-// CHECK: scf.yield %64, %65, %66, %67, %68, %69, %70, %71, %72, %73, %74 : tensor<32xi32>, tensor<32xi32>, tensor<32xi32>, tensor<32xi32>, tensor<32xi32>, tensor<32xi32>, tensor<32xi32>, tensor<32xi32>, tensor<32xi32>, tensor<32xi32>, tensor<32xi32>
+// CHECK: %[[RESULTS:.*]]:22 = scf.for %arg1 = %c0 to %c128 step %c32 iter_args(%arg2 = %arg0, %arg3 = %0, %arg4 = %arg0, %arg5 = %1, %arg6 = %arg0, %arg7 = %3, %arg8 = %arg0, %arg9 = %6, %arg10 = %arg0, %arg11 = %10, %arg12 = %arg0, %arg13 = %15, %arg14 = %arg0, %arg15 = %21, %arg16 = %arg0, %arg17 = %28, %arg18 = %arg0, %arg19 = %36, %arg20 = %arg0, %arg21 = %45, %arg22 = %arg0, %arg23 = %55) -> (!tt.ptr<f32>, tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>) {
+// CHECK: scf.yield %arg2, %64, %arg4, %65, %arg6, %66, %arg8, %67, %arg10, %68, %arg12, %69, %arg14, %70, %arg16, %71, %arg18, %72, %arg20, %73, %arg22, %74 : !tt.ptr<f32>, tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>
+// CHECK-NEXT: }
+// CHECK-NEXT: %[[RESULT2:.*]] = tt.splat %[[RESULTS]]#20 : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>>
+// CHECK-NEXT  %[[RESULT3:.*]] = tt.addptr %[[RESULT2]], %[[RESULTS]]#21 : tensor<32x!tt.ptr<f32>>, tensor<32xi32>
 tt.func @for_multi_iter_args_test(%arg0: !tt.ptr<f32>) -> tensor<32xf32> {
   %c0 = arith.constant 0 : index
   %c128 = arith.constant 128 : index
@@ -1185,23 +1188,23 @@ tt.func @tensor_ptr_if_two_region_base_ptr_different_test(%arg0: !tt.ptr<f32>, %
 
 // -----
 // CHECK-LABEL: tt.func @for_nested_while
-// CHECK: %[[TEMP7:.*]]:2 = scf.for %arg2 = %c0 to %c128 step %c32 iter_args(%arg3 = %0, %arg4 = %0) -> (tensor<32xi32>, tensor<32xi32>) {
+// CHECK: %[[TEMP7:.*]]:3 = scf.for %arg2 = %c0 to %c128 step %c32 iter_args(%arg3 = %0, %arg4 = %arg0, %arg5 = %0) -> (tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>) {
 // CHECK:      %[[TEMP0:.*]] = tt.splat %5 : i32 -> tensor<32xi32>
 // CHECK-NEXT: %[[TEMP1:.*]] = arith.addi %6, %[[TEMP0]] : tensor<32xi32>
-// CHECK-NEXT: %[[TEMP2:.*]] = arith.addi %[[TEMP1]], %arg4 : tensor<32xi32>
-// CHECK-NEXT: %[[TEMP3:.*]] = scf.while (%arg5 = %[[TEMP2]]) : (tensor<32xi32>) -> tensor<32xi32> {
+// CHECK-NEXT: %[[TEMP2:.*]] = arith.addi %[[TEMP1]], %arg5 : tensor<32xi32>
+// CHECK-NEXT: %[[TEMP3:.*]]:2 = scf.while (%arg6 = %arg4, %arg7 = %[[TEMP2]]) : (!tt.ptr<f32>, tensor<32xi32>) -> (!tt.ptr<f32>, tensor<32xi32>) {
 // CHECK-NEXT:   %[[TEMP4:.*]] = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
-// CHECK-NEXT:   %[[TEMP5:.*]] = arith.addi %[[TEMP4]], %arg5 : tensor<32xi32>
-// CHECK-NEXT:   scf.condition(%arg1) %[[TEMP5]] : tensor<32xi32>
+// CHECK-NEXT:   %[[TEMP5:.*]] = arith.addi %[[TEMP4]], %arg7 : tensor<32xi32>
+// CHECK-NEXT:   scf.condition(%arg1) %arg6, %[[TEMP5]] : !tt.ptr<f32>, tensor<32xi32>
 // CHECK-NEXT: } do {
-// CHECK-NEXT: ^bb0(%arg5: tensor<32xi32>):
-// CHECK-NEXT:   %[[TEMP6:.*]] = arith.addi %arg5, %cst : tensor<32xi32>
-// CHECK-NEXT:   scf.yield %[[TEMP6]] : tensor<32xi32>
+// CHECK-NEXT: ^bb0(%arg6: !tt.ptr<f32>, %arg7: tensor<32xi32>):
+// CHECK-NEXT:   %[[TEMP6:.*]] = arith.addi %arg7, %cst : tensor<32xi32>
+// CHECK-NEXT:   scf.yield %arg6, %[[TEMP6]] : !tt.ptr<f32>, tensor<32xi32>
 // CHECK-NEXT: }
-// CHECK-NEXT: scf.yield %[[TEMP1]], %[[TEMP3]] : tensor<32xi32>, tensor<32xi32>
+// CHECK-NEXT: scf.yield %[[TEMP1]], %[[TEMP3]]#0, %[[TEMP3]]#1 : tensor<32xi32>, !tt.ptr<f32>, tensor<32xi32>
 // CHECK-NEXT: }
-// CHECK-NEXT: %[[TEMP8:.*]] = tt.splat %arg0 : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>>
-// CHECK-NEXT: %[[TEMP9:.*]] = tt.addptr %[[TEMP8]], %[[TEMP7]]#1 : tensor<32x!tt.ptr<f32>>, tensor<32xi32>
+// CHECK-NEXT: %[[TEMP8:.*]] = tt.splat %[[TEMP7]]#1 : !tt.ptr<f32> -> tensor<32x!tt.ptr<f32>>
+// CHECK-NEXT: %[[TEMP9:.*]] = tt.addptr %[[TEMP8]], %[[TEMP7]]#2 : tensor<32x!tt.ptr<f32>>, tensor<32xi32>
 tt.func @for_nested_while(%arg0: !tt.ptr<f32>, %arg1: i1) -> tensor<32xf32> {
   %c0 = arith.constant 0 : index
   %c128 = arith.constant 128 : index
@@ -1291,4 +1294,140 @@ tt.func @control_flow_cond_br_with_three_blocks_test(%arg0: i1, %arg1: !tt.ptr<f
 ^bb3(%8: tensor<128x!tt.ptr<f32>>):  // 2 preds: ^bb1, ^bb2
   %9 = tt.load %8 : tensor<128x!tt.ptr<f32>>
   tt.return %9 : tensor<128xf32>
+}
+
+// -----
+// CHECK-LABEL: tt.func @for_addptr_use_splat_test
+// CHECK-SAME: %[[ARG0:.*]]: !tt.ptr<f32>, %[[ARG1:.*]]: !tt.ptr<f32>, %[[ARG2:.*]]: i32, %[[ARG3:.*]]: i32)
+// CHECK: %[[CST:.*]] = arith.constant dense<0> : tensor<1x1xi32>
+// CHECK: %[[C0_I32:.*]] = arith.constant 0 : i32
+// CHECK: %[[C1_I32:.*]] = arith.constant 1 : i32
+// CHECK: %[[C2_I32:.*]] = arith.constant 2 : i32
+// CHECK: %[[CST_0:.*]] = arith.constant dense<0.000000e+00> : tensor<1x1xf32>
+// CHECK: %[[ARG4:.*]] = arith.addi %[[ARG3]], %[[ARG2]] : i32
+// CHECK: %[[ARG5:.*]] = tt.addptr %[[ARG1]], %[[ARG4]] : !tt.ptr<f32>, i32
+// CHECK: %[[ARG6:.*]] = arith.muli %[[ARG2]], %[[ARG3]] : i32
+// CHECK: %[[ARG7:.*]] = tt.splat %[[ARG6]] : i32 -> tensor<1x1xi32>
+// CHECK: %[[ARG8:.*]]:2 = scf.for %[[ARG9:.*]] = %[[C0_I32]] to %[[C2_I32]] step %[[C1_I32]] iter_args(%[[ITER_PTR:.*]] = %[[ARG5]], %[[ARG10:.*]] = %[[CST]]) -> (!tt.ptr<f32>, tensor<1x1xi32>)  : i32 {
+// CHECK:   %[[ARG11:.*]] = tt.splat %[[ITER_PTR]] : !tt.ptr<f32> -> tensor<1x1x!tt.ptr<f32>>
+// CHECK:   %[[ARG12:.*]] = tt.addptr %[[ARG11]], %[[ARG10]] : tensor<1x1x!tt.ptr<f32>>, tensor<1x1xi32>
+// CHECK:   tt.store %[[ARG12]], %[[CST_0]] : tensor<1x1x!tt.ptr<f32>>
+// CHECK:   %[[ARG13:.*]] = arith.addi %[[ARG7]], %[[ARG10]] : tensor<1x1xi32>
+// CHECK:   scf.yield %[[ITER_PTR]], %[[ARG13]] : !tt.ptr<f32>, tensor<1x1xi32>
+// CHECK: }
+// CHECK: %[[ARG14:.*]] = tt.splat %[[ARG8]]#0 : !tt.ptr<f32> -> tensor<1x1x!tt.ptr<f32>>
+// CHECK: %[[ARG15:.*]] = tt.addptr %[[ARG14]], %[[ARG8]]#1 : tensor<1x1x!tt.ptr<f32>>, tensor<1x1xi32>
+// CHECK: tt.return %[[ARG15]] : tensor<1x1x!tt.ptr<f32>
+tt.func @for_addptr_use_splat_test(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %arg3: i32) -> tensor<1x1x!tt.ptr<f32>> {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %c2 = arith.constant 2 : i32
+  %cst = arith.constant dense<0.000000e+00> : tensor<1x1xf32>
+
+  %1 = tt.addptr %arg1, %arg2 : !tt.ptr<f32>, i32
+  %2 = tt.addptr %1, %arg3 : !tt.ptr<f32>, i32
+  %3 = tt.splat %2 : !tt.ptr<f32> -> tensor<1x1x!tt.ptr<f32>>
+
+  %4 = arith.muli %arg2, %arg3 : i32
+  %5 = tt.splat %4 : i32 -> tensor<1x1xi32>
+  %6 = scf.for %arg4 = %c0 to %c2 step %c1 iter_args(%arg5 = %3) -> (tensor<1x1x!tt.ptr<f32>>)  : i32 {
+    tt.store %arg5, %cst : tensor<1x1x!tt.ptr<f32>>
+    %7 = tt.addptr %arg5, %5 : tensor<1x1x!tt.ptr<f32>>, tensor<1x1xi32>
+    scf.yield %7 : tensor<1x1x!tt.ptr<f32>>
+  }
+  tt.return %6 : tensor<1x1x!tt.ptr<f32>>
+}
+
+// -----
+// CHECK-LABEL: tt.func @if_addptr_use_splat_test
+// CHECK-SAME: %[[ARG0:.*]]: !tt.ptr<f32>, %[[ARG1:.*]]: !tt.ptr<f32>, %[[ARG2:.*]]: i32, %[[ARG3:.*]]: i32, %[[ARG4:.*]]: i1)
+// CHECK: %[[CST:.*]] = arith.constant dense<0> : tensor<1x1xi32>
+// CHECK: %[[CST_0:.*]] = arith.constant dense<0.000000e+00> : tensor<1x1xf32>
+// CHECK: %[[ARG5:.*]] = arith.addi %[[ARG3]], %[[ARG2]] : i32
+// CHECK: %[[ARG6:.*]] = tt.addptr %[[ARG1]], %[[ARG5]] : !tt.ptr<f32>, i32
+// CHECK: %[[ARG7:.*]] = tt.splat %[[ARG6]] : !tt.ptr<f32> -> tensor<1x1x!tt.ptr<f32>>
+// CHECK: %[[ARG8:.*]] = arith.muli %[[ARG2]], %[[ARG3]] : i32
+// CHECK: %[[ARG9:.*]] = tt.splat %[[ARG8]] : i32 -> tensor<1x1xi32>
+// CHECK: %[[ARG10:.*]] = scf.if %[[ARG4]] -> (tensor<1x1xi32>) {
+// CHECK:   tt.store %[[ARG7]], %[[CST_0]] : tensor<1x1x!tt.ptr<f32>>
+// CHECK:   scf.yield %[[ARG9]] : tensor<1x1xi32>
+// CHECK: } else {
+// CHECK:   tt.store %[[ARG7]], %[[CST_0]] : tensor<1x1x!tt.ptr<f32>>
+// CHECK:   scf.yield %[[CST]] : tensor<1x1xi32>
+// CHECK: }
+// CHECK: %[[ARG11:.*]] = tt.splat %[[ARG6]] : !tt.ptr<f32> -> tensor<1x1x!tt.ptr<f32>>
+// CHECK: %[[ARG12:.*]] = tt.addptr %[[ARG11]], %[[ARG10]] : tensor<1x1x!tt.ptr<f32>>, tensor<1x1xi32>
+// CHECK: tt.return %[[ARG12]] : tensor<1x1x!tt.ptr<f32>>
+tt.func @if_addptr_use_splat_test(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %arg3: i32, %arg4: i1) -> tensor<1x1x!tt.ptr<f32>> {
+  %cst = arith.constant dense<0.000000e+00> : tensor<1x1xf32>
+
+  %1 = tt.addptr %arg1, %arg2 : !tt.ptr<f32>, i32
+  %2 = tt.addptr %1, %arg3 : !tt.ptr<f32>, i32
+  %3 = tt.splat %2 : !tt.ptr<f32> -> tensor<1x1x!tt.ptr<f32>>
+
+  %4 = arith.muli %arg2, %arg3 : i32
+  %5 = tt.splat %4 : i32 -> tensor<1x1xi32>
+
+  %6 = scf.if %arg4 -> (tensor<1x1x!tt.ptr<f32>>) {
+    tt.store %3, %cst : tensor<1x1x!tt.ptr<f32>>
+    %7 = tt.addptr %3, %5 : tensor<1x1x!tt.ptr<f32>>, tensor<1x1xi32>
+    scf.yield %7 : tensor<1x1x!tt.ptr<f32>>
+  } else {
+    tt.store %3, %cst : tensor<1x1x!tt.ptr<f32>>
+    scf.yield %3 : tensor<1x1x!tt.ptr<f32>>
+  }
+  tt.return %6 : tensor<1x1x!tt.ptr<f32>>
+}
+
+// -----
+// CHECK-LABEL: tt.func @while_addptr_use_splat_test
+// CHECK-SAME: %[[ARG0:.*]]: !tt.ptr<f32>, %[[ARG1:.*]]: !tt.ptr<f32>, %[[ARG2:.*]]: i32, %[[ARG3:.*]]: i32)
+// CHECK: %[[CST:.*]] = arith.constant dense<0> : tensor<1x1xi32>
+// CHECK: %[[CST_I32:.*]] = arith.constant 0 : i32
+// CHECK: %[[CST1_I32:.*]] = arith.constant 1 : i32
+// CHECK: %[[CST2_I32:.*]] = arith.constant 2 : i32
+// CHECK: %[[CST_0:.*]] = arith.constant dense<0.000000e+00> : tensor<1x1xf32>
+// CHECK: %[[ARG4:.*]] = arith.addi %[[ARG3]], %[[ARG2]] : i32
+// CHECK: %[[ARG5:.*]] = tt.addptr %[[ARG1]], %[[ARG4]] : !tt.ptr<f32>, i32
+// CHECK: %[[ARG6:.*]] = arith.muli %[[ARG2]], %[[ARG3]] : i32
+// CHECK: %[[ARG7:.*]] = tt.splat %[[ARG6]] : i32 -> tensor<1x1xi32>
+// CHECK: %[[ARG8:.*]]:3 = scf.while (%arg4 = %c0_i32, %arg5 = %1, %arg6 = %cst) : (i32, !tt.ptr<f32>, tensor<1x1xi32>) -> (i32, !tt.ptr<f32>, tensor<1x1xi32>) {
+// CHECK:   %[[ARG11:.*]] = arith.cmpi slt, %arg4, %c2_i32 : i32
+// CHECK:   scf.condition(%[[ARG11]]) %arg4, %arg5, %arg6 : i32, !tt.ptr<f32>, tensor<1x1xi32>
+// CHECK: } do {
+// CHECK: ^bb0(%arg4: i32, %arg5: !tt.ptr<f32>, %arg6: tensor<1x1xi32>):
+// CHECK:   %7 = tt.splat %arg5 : !tt.ptr<f32> -> tensor<1x1x!tt.ptr<f32>>
+// CHECK:   %8 = tt.addptr %7, %arg6 : tensor<1x1x!tt.ptr<f32>>, tensor<1x1xi32>
+// CHECK:   tt.store %8, %cst_0 : tensor<1x1x!tt.ptr<f32>>
+// CHECK:   %9 = arith.addi %3, %arg6 : tensor<1x1xi32>
+// CHECK:   %10 = arith.addi %arg4, %c1_i32 : i32
+// CHECK:   scf.yield %10, %arg5, %9 : i32, !tt.ptr<f32>, tensor<1x1xi32>
+// CHECK: }
+// CHECK:  %5 = tt.splat %4#1 : !tt.ptr<f32> -> tensor<1x1x!tt.ptr<f32>>
+// CHECK:  %6 = tt.addptr %5, %4#2 : tensor<1x1x!tt.ptr<f32>>, tensor<1x1xi32>
+// CHECK:  tt.return %6 : tensor<1x1x!tt.ptr<f32>>
+tt.func @while_addptr_use_splat_test(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %arg3: i32) -> tensor<1x1x!tt.ptr<f32>> {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %c2 = arith.constant 2 : i32
+  %cst = arith.constant dense<0.000000e+00> : tensor<1x1xf32>
+
+  %1 = tt.addptr %arg1, %arg2 : !tt.ptr<f32>, i32
+  %2 = tt.addptr %1, %arg3 : !tt.ptr<f32>, i32
+  %3 = tt.splat %2 : !tt.ptr<f32> -> tensor<1x1x!tt.ptr<f32>>
+
+  %4 = arith.muli %arg2, %arg3 : i32
+  %5 = tt.splat %4 : i32 -> tensor<1x1xi32>
+
+  %6, %7 = scf.while (%arg4 = %c0, %arg5 = %3) : (i32, tensor<1x1x!tt.ptr<f32>>) -> (i32, tensor<1x1x!tt.ptr<f32>>) {
+    %cond = arith.cmpi slt, %arg4, %c2 : i32
+    scf.condition(%cond) %arg4, %arg5 : i32, tensor<1x1x!tt.ptr<f32>>
+  } do {
+  ^bb0(%arg4: i32, %arg5: tensor<1x1x!tt.ptr<f32>>):
+    tt.store %arg5, %cst : tensor<1x1x!tt.ptr<f32>>
+    %8 = tt.addptr %arg5, %5 : tensor<1x1x!tt.ptr<f32>>, tensor<1x1xi32>
+    %arg4_next = arith.addi %arg4, %c1 : i32
+    scf.yield %arg4_next, %8 : i32, tensor<1x1x!tt.ptr<f32>>
+  }
+  tt.return %7 : tensor<1x1x!tt.ptr<f32>>
 }

--- a/tools/ci/daily/triton-linalg_daliy.pipeline
+++ b/tools/ci/daily/triton-linalg_daliy.pipeline
@@ -8,7 +8,7 @@ cnpipe {
         }
         container {
             networkPolicy "cncl-no-internnet-access"
-            image 'yellow.hub.cambricon.com/genesis/devel/x86_64/genesis:0.7.13-x86_64-ubuntu2004-prebuild-thirdparty-py_3_10'
+            image 'yellow.hub.cambricon.com/genesis/devel/x86_64/genesis:v1.3.0-x86_64-ubuntu2204-prebuild-thirdparty-py_3_10'
             runArgs "--network=host --privileged -v /usr/bin/cnmon:/usr/bin/cnmon --device=/dev/cambricon_dev0:/dev/cambricon_dev0 --device=/dev/cambricon_ctl"
         }
         resReq {
@@ -41,7 +41,7 @@ cnpipe {
         }
         container {
             networkPolicy "cncl-no-internnet-access"
-            image 'yellow.hub.cambricon.com/genesis/devel/x86_64/genesis:0.7.13-x86_64-ubuntu2004-prebuild-thirdparty-py_3_10'
+            image 'yellow.hub.cambricon.com/genesis/devel/x86_64/genesis:v1.3.0-x86_64-ubuntu2204-prebuild-thirdparty-py_3_10'
             runArgs "--network=host --privileged -v /usr/bin/cnmon:/usr/bin/cnmon --device=/dev/cambricon_dev0:/dev/cambricon_dev0 --device=/dev/cambricon_ctl"
         }
         resReq {
@@ -72,7 +72,7 @@ cnpipe {
         }
         container {
             networkPolicy "cncl-no-internnet-access"
-            image 'yellow.hub.cambricon.com/genesis/devel/x86_64/genesis:0.7.13-x86_64-ubuntu2004-prebuild-thirdparty-py_3_10'
+            image 'yellow.hub.cambricon.com/genesis/devel/x86_64/genesis:v1.3.0-x86_64-ubuntu2204-prebuild-thirdparty-py_3_10'
             runArgs "--network=host --privileged -v /usr/bin/cnmon:/usr/bin/cnmon --device=/dev/cambricon_dev0:/dev/cambricon_dev0 --device=/dev/cambricon_ctl"
         }
         resReq {


### PR DESCRIPTION
Update Content:

**Operators**

Newly added: aux.bitcast_ext

Newly added: linalg_ext.tri

Newly added: linalg_ext.flip

Newly added: linalg_ext.reduce_sum, linalg_ext.reduce_max, linalg_ext.reduce_min, linalg_ext.reduce_max_nan, linalg_ext.reduce_min_nan

Extended linalg_ext.scan to support the inclusive mode

**Features**

Refactored and extended the functionality of pointer continuity analysis.

Extended the supported scenarios for moving the extract op forward.